### PR TITLE
BUGFIX/MAJOR(memcached): Add maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ An Ansible role for manage memcached. Specifically, the responsibilities of this
 | `openio_memcached_maxconn` | 1024 |  Limit the number of simultaneous incoming connections |
 | `openio_memcached_namespace` | `"OPENIO" ` | Namespace OpenIO SDS |
 | `openio_memcached_serviceid` | `"0"` | Service ID |
+| `openio_memcached_provision_only` | `False` | Provision only without restarting / bootstrapping |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,5 +12,6 @@ openio_memcached_gridinit_dir: "/etc/gridinit.d/{{ openio_memcached_namespace }}
 openio_memcached_gridinit_file_prefix: ""
 openio_memcached_gridinit_on_die: respawn
 openio_memcached_gridinit_start_at_boot: true
+openio_memcached_provision_only: false
 
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,8 @@
   shell: |
     gridinit_cmd reload
     gridinit_cmd restart  {{ openio_memcached_namespace }}-{{ openio_memcached_servicename }}
-  when: _memcached_conf.changed
+  when:
+    - _memcached_conf.changed
+    - not openio_memcached_provision_only
   tags: configure
 ...


### PR DESCRIPTION
##### SUMMARY

Lack of maintenance mode in memcached service delivery --> restart services and reload gridinit even if openio_maintenance_mode is set to true 

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION