### PR TITLE
CHANGE(memcached): Ensure service is started or restarted at the end …

### DIFF
--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -2,13 +2,13 @@
 ---
 - hosts: all
   become: true
+  vars:
+    openio_bootstrap: true
   roles:
     - role: users
     - role: repository
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.10"
+      openio_repository_mirror_host: mirror2.openio.io
     - role: gridinit
       openio_gridinit_per_ns: true
       openio_gridinit_namespace: "TRAVIS"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,12 +39,36 @@
   tags: install
   register: _memcached_conf
 
-- name: restart memcached
+- name: "restart memcached to apply the new configuration"
   shell: |
     gridinit_cmd reload
     gridinit_cmd restart  {{ openio_memcached_namespace }}-{{ openio_memcached_servicename }}
+  register: _restart_memcached
   when:
-    - _memcached_conf.changed
+    - _memcached_conf is changed
     - not openio_memcached_provision_only
   tags: configure
+
+- block:
+    - name: "Ensure memcached is started"
+      command: gridinit_cmd start {{ openio_memcached_namespace }}-{{ openio_memcached_servicename }}
+      register: _start_memcached
+      changed_when: '"Success" in _start_memcached.stdout'
+      when:
+        - not openio_memcached_provision_only
+        - _restart_memcached is skipped
+      tags: configure
+
+    - name: check memcached
+      wait_for:
+        host: "{{ openio_memcached_bind_address }}"
+        port: "{{ openio_memcached_bind_port }}"
+      register: _memcached_check
+      retries: 3
+      delay: 5
+      until: _memcached_check is success
+      changed_when: false
+      when:
+        - not openio_memcached_provision_only
+  when: openio_bootstrap | d(false)
 ...


### PR DESCRIPTION
…of role

 ##### SUMMARY
Until 18.10, a voluntarily stopped service was not revived by a reproviosionning.

In 19.04, the `maintenance` mode becomes the default mode.

To avoid having to force (ie. deletion of conf files) the restart of a service delivered first, by error, in maintenance mode: We have to make sure that service is started and it works well at the end of the role.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION