### PR TITLE
CHANGE(memcached): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ An Ansible role for manage memcached. Specifically, the responsibilities of this
 | `openio_memcached_namespace` | `"OPENIO" ` | Namespace OpenIO SDS |
 | `openio_memcached_serviceid` | `{{ 0 + openio_legacy_serviceid | d(0) | int }}` | Service ID |
 | `openio_memcached_provision_only` | `False` | Provision only without restarting / bootstrapping |
+| `openio_memcached_package_upgrade` | `false` | Set the packages to the latest version (to be set in extra_vars) |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,5 +14,5 @@ openio_memcached_gridinit_file_prefix: ""
 openio_memcached_gridinit_on_die: respawn
 openio_memcached_gridinit_start_at_boot: true
 openio_memcached_provision_only: false
-
+openio_memcached_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 ...

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_memcached_package_upgrade else 'present' }}"
   with_items: "{{ openio_memcached_packages }}"
   loop_control:
     loop_var: pkg

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_memcached_package_upgrade else 'present' }}"
   with_items: "{{ openio_memcached_packages }}"
   loop_control:
     loop_var: pkg


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION