### PR TITLE
CHANGE(memcached): Change default of `openio_memcached_cachesize_MBytes`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ openio_memcached_bind_address:
   | default(hostvars[inventory_hostname]['ansible_' + openio_memcached_bind_interface]['ipv4']['address']) }}"
 openio_memcached_bind_port: 6019
 openio_memcached_maxconn: 8192
-openio_memcached_cachesize_MBytes: 64
+openio_memcached_cachesize_MBytes: 512
 openio_memcached_gridinit_dir: "/etc/gridinit.d/{{ openio_memcached_namespace }}"
 openio_memcached_gridinit_file_prefix: ""
 openio_memcached_gridinit_on_die: respawn


### PR DESCRIPTION
 ##### SUMMARY

Set the amount of memory allocated to 512 MB.
The more RAM you allocate, the more data you can store and therefore the more effective your cache is

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
Do not specify a memory allocation larger than your available RAM.
f you specify too large a value, then some RAM allocated for memcached uses swap space, and not physical RAM.
This may lead to delays when storing and retrieving values, because data is swapped to disk, instead of storing the data directly in RAM.